### PR TITLE
Fix: Ensure consistent hook order in BottomNavbar

### DIFF
--- a/src/components/BottomNavbar.tsx
+++ b/src/components/BottomNavbar.tsx
@@ -48,10 +48,6 @@ export function BottomNavbar() {
     }
   };
 
-  if (!currentSong) {
-    return null;
-  }
-
   const progressPercentage = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   const canvasRef = useRef<HTMLCanvasElement>(null);


### PR DESCRIPTION
This commit moves the `if (!currentSong)` block in `BottomNavbar.tsx` to after all the hooks have been called. This ensures that the hooks are always called in the same order, which fixes the 'Rendered more hooks than during the previous render' error.