### PR TITLE
Fix: Correct initialization order in MusicPlayerContext

### DIFF
--- a/src/contexts/MusicPlayerContext.tsx
+++ b/src/contexts/MusicPlayerContext.tsx
@@ -206,6 +206,19 @@ export const MusicPlayerProvider: React.FC<{ children: ReactNode }> = ({ childre
     staleTime: 5 * 60 * 1000,
   });
 
+  // Mobile-optimized queue management with aggressive prefetching
+  const setQueue = useCallback((newQueue: Song[], startIndex: number = 0) => {
+    setQueueState(newQueue);
+    setCurrentQueueIndex(startIndex);
+    if (newQueue.length > 0) {
+      setCurrentSong(newQueue[startIndex]);
+      // Start immediate prefetching for mobile
+      setTimeout(() => {
+        startBackgroundPrefetch(newQueue, resolveMediaUrlWithSession, startIndex);
+      }, 100);
+    }
+  }, [resolveMediaUrlWithSession]);
+
   // Initialize with aggressive prefetching
   useEffect(() => {
     if (songsError) console.error("Error in fetchedSongs query:", songsError);


### PR DESCRIPTION
This commit moves the `setQueue` function in `MusicPlayerContext.tsx` to before the `useEffect` hook that uses it. This fixes the 'ReferenceError: Cannot access 'setQueue' before initialization' error.