### PR TITLE
fix: Fix build error by externalizing capacitor-native-audio

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,9 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      external: ["capacitor-native-audio"],
+    },
+  },
 }));


### PR DESCRIPTION
This commit fixes the build error that was occurring due to the `capacitor-native-audio` module not being resolved correctly by Rollup.

- The `capacitor-native-audio` module has been added to the `build.rollupOptions.external` array in the `vite.config.ts` file.