### PR TITLE
fix: Fix build error by adding a path alias for capacitor-native-audio

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,11 +17,7 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-    },
-  },
-  build: {
-    rollupOptions: {
-      external: ["capacitor-native-audio"],
+      "capacitor-native-audio": path.resolve(__dirname, "node_modules/@mediagrid/capacitor-native-audio/dist/esm/index.js"),
     },
   },
 }));


### PR DESCRIPTION
This commit fixes the build error that was occurring due to the `capacitor-native-audio` module not being resolved correctly by Rollup.

- A path alias for `capacitor-native-audio` has been added to the `resolve.alias` object in the `vite.config.ts` file.